### PR TITLE
Fix port arguments in string form (grease)

### DIFF
--- a/grease/grease/core.lua
+++ b/grease/grease/core.lua
@@ -60,7 +60,7 @@ function client:connect(host, port, dns)
 	-- Set it up for our new connection.
 	self:createSocket()
 	self.host = host
-	self.port = port
+	self.port = tonumber(port)
 	-- Ask our implementation to actually connect.
 	local success, err = self:_connect()
 	if not success then
@@ -170,7 +170,7 @@ end
 function server:listen(port)
 	-- Create a socket, set the port and listen.
 	self:createSocket()
-	self.port = port
+	self.port = tonumber(port)
 	self:_listen()
 end
 


### PR DESCRIPTION
As it turns out, grease (and, by extension, LUBE) supports providing the port argument for `server:listen` as a string. However, if you provide the port as a string for `client:connect`, it fails *silently*! It just simply never receives any data, due to a failing `==` comparison. I spent literal hours chasing this one down...

This pull request calls `tonumber` on the port arguments in both places, for consistency. It also preserves backwards compatibility by doing so.